### PR TITLE
fixed glass pane recipe

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -4137,7 +4137,7 @@ production_recipes:
         amount: 192
     outputs:
       Glass Pane:
-        material: GLASS_PANE
+        material: THIN_GLASS
         amount: 768
   Smelt_Bottles:
     name: Smelt Bottles


### PR DESCRIPTION
Another victim of Mojang's inconsistent naming: THIN_GLASS vs STAINED_GLASS_PANE
