### PR TITLE
Add Bastion Factory

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -2288,6 +2288,29 @@ production_factories:
     repair_inputs:
       Stick:
         material: STICK
+  Bastion_Factory:
+    name: Bastion Factory
+    fuel:
+      Charcoal:
+        material: COAL
+        durability: 1
+    inputs:
+      Obsidian:
+        material: OBSIDIAN
+        amount: 3328
+      Sticky_piston:
+        material: STICKY_PISTON
+        amount: 128
+    recipes:
+      - Produce_Bastions
+    repair_multiple: 32
+    repair_inputs:
+      Emerald_block:
+        material: EMERALD_BLOCK
+        amount: 8
+      Sticky_piston:
+        material: STICKY_PISTON
+        amount: 1
 production_recipes:
   Wood_XP_Bottle_0:
     name: Brew XP Bottles  - 1
@@ -6542,4 +6565,24 @@ production_recipes:
       Packed_Ice:
         material: PACKED_ICE
         amount: 576
+  Produce_Bastions:
+    name: Produce Bastions
+    production_time: 32
+    inputs:
+      Redstone_block:
+        material: REDSTONE_BLOCK
+        amount: 64
+      Lapis_block:
+        material: LAPIS_BLOCK
+        amount: 64
+      Emerald_block:
+        material: EMERALD_BLOCK
+        amount: 64
+      Coal_block:
+        material: COAL_BLOCK
+        amount: 64
+    outputs:
+      Bastion:
+        material: SPONGE
+        amount: 32
 


### PR DESCRIPTION
Too much discussion, not enough action. If nobody else will do the actual config, I'll suggest one that suits me :P .

```
**Bastion Factory** - 3328 Obsidian, 128 Sticky Pistons (full double chest)

32 Bastions (Sponge) for 64 Redstone Blocks, 64 Lapis Blocks, 64 Emerald Blocks, 64 Coal Blocks

Full repair costs 256 Emerald Blocks, 32 Sticky Pistons
```

This is a bit different to other factories as it has quite different construction, maintenance and use costs. The initial cost isn't too crippling other than requiring some coordination and preferably an advanced redstone factory, but the maintenance is designed as a burden which will require good logistics to collect the recipe inputs and regularly run to justify.

EDIT: Drop lapis cost - too high in ore
EDIT 2: Doubled maintenance - looks too light on review
