### PR TITLE
Alternative Bastion Factory Cost - villagers

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -2297,10 +2297,14 @@ production_factories:
     inputs:
       Obsidian:
         material: OBSIDIAN
-        amount: 3328
+        amount: 640
       Sticky_piston:
         material: STICKY_PISTON
         amount: 128
+      Villager_egg:
+        material: MONSTER_EGG
+        durability: 120
+        amount: 64
     recipes:
       - Produce_Bastions
     repair_multiple: 32
@@ -2310,6 +2314,10 @@ production_factories:
         amount: 8
       Sticky_piston:
         material: STICKY_PISTON
+        amount: 1
+      Villager_egg:
+        material: MONSTER_EGG
+        durability: 120
         amount: 1
 production_recipes:
   Wood_XP_Bottle_0:

--- a/config.yml
+++ b/config.yml
@@ -2288,6 +2288,29 @@ production_factories:
     repair_inputs:
       Stick:
         material: STICK
+  Bastion_Factory:
+    name: Bastion Factory
+    fuel:
+      Charcoal:
+        material: COAL
+        durability: 1
+    inputs:
+      Obsidian:
+        material: OBSIDIAN
+        amount: 3328
+      Sticky_piston:
+        material: STICKY_PISTON
+        amount: 128
+    recipes:
+      - Produce_Bastions
+    repair_multiple: 32
+    repair_inputs:
+      Emerald_block:
+        material: EMERALD_BLOCK
+        amount: 8
+      Sticky_piston:
+        material: STICKY_PISTON
+        amount: 1
 production_recipes:
   Wood_XP_Bottle_0:
     name: Brew XP Bottles  - 1
@@ -6542,4 +6565,24 @@ production_recipes:
       Packed_Ice:
         material: PACKED_ICE
         amount: 576
+  Produce_Bastions:
+    name: Produce Bastions
+    production_time: 32
+    inputs:
+      Redstone_block:
+        material: REDSTONE_BLOCK
+        amount: 64
+      Lapis_block:
+        material: LAPIS_BLOCK
+        amount: 64
+      Emerald_block:
+        material: EMERALD_BLOCK
+        amount: 64
+      Coal_block:
+        material: COAL_BLOCK
+        amount: 64
+    outputs:
+      Bastion:
+        material: SPONGE
+        amount: 32
 


### PR DESCRIPTION
Alternative construction cost for https://github.com/ttk2/FactoryMod/pull/17

```
**Bastion Factory** - 640 Obsidian, 128 Sticky Pistons, 64 Villager Spawn Eggs

32 Bastions (Sponge) for 64 Redstone Blocks, 64 Lapis Blocks, 64 Emerald Blocks, 64 Coal Blocks

Full repair costs 256 Emerald Blocks, 32 Sticky Pistons, 32 Villager Eggs
```

Instead of so much obsidian, which it has been pointed out is highly bottable, this requires a stack of villager eggs to set up and maintain. Being able to keep a factory therefore requires building and protecting a safe and stable village - a simulated "workforce".
