### PR TITLE
Ribagi's system with amended costs

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -6622,25 +6622,25 @@ production_recipes:
         amount: 8
 	  Cracked Stone Brick:
 	    material: SMOOTH_BRICK
-		amount: 8
+        amount: 8
         durability: 2
 	outputs:
 	  Walls:
 	    material: INK_SACK
-		amount: 1
-		durablity: 4
-		display_name: Walls
-		lore: An item used to create a Bastion Block
+        amount: 1
+        durablity: 4
+        display_name: Walls
+        lore: An item used to create a Bastion Block
   Bastion_Base:
 	name: Base
 	production_time: 2
 	inputs:
 	  Diamond Ore:
 	    material: DIAMOND_ORE
-		amount: 16
+        amount: 16
 	  Redstone Ore:
 	    material: REDSTONE ORE
-		amount: 4
+        amount: 4
 	outputs:
 	  Base:
 	   material: IRON_INGOT
@@ -6653,10 +6653,10 @@ production_recipes:
 	inputs:
 	  Iron Ingot:
 	    material: IRON_IGNOT
-		amount: 4
+        amount: 4
 	  Gold Ore:
 	    material: GOLD_ORE
-		amount: 2
+        amount: 2
 	outputs:
 	  Gearbox:
 	   material: WATCH
@@ -6732,8 +6732,8 @@ production_recipes:
         durability: 10
 	  Red Sand:
 	    material: SAND
-		amount: 64
-		durability: 1
+        amount: 64
+        durability: 1
 	outputs:
 	  Object d'art:
 	   material: FLINT
@@ -6744,10 +6744,10 @@ production_recipes:
     inputs:
 	  Chest:
 	    material: CHEST
-		amount: 8
+        amount: 8
 	  Iron Ignot:
 	    material: IRON_IGNOT
-		amount: 4
+        amount: 4
 	outputs:
 	  Framing:
 	   material: STICK
@@ -6761,7 +6761,7 @@ production_recipes:
 	   amount: 4
 	  Nether Brick:
 	   material: NETHER_BRICK
-	   amount: 64		
+	   amount: 64        
 	outputs:
 	  Flooring:
 	   material: CLAY_BRICK

--- a/config.yml
+++ b/config.yml
@@ -2056,7 +2056,7 @@ production_factories:
       - Dye_Light_Blue_Stained_Glass_Pane
       - Dye_Red_Stained_Glass_Pane
       - Dye_Lime_Stained_Glass_Pane
-	  _Objet_Dart
+      - Bastion_Objet_Dart
     repair_multiple: 2
     repair_inputs:
       Lapis Lazuli:

--- a/config.yml
+++ b/config.yml
@@ -1092,7 +1092,7 @@ production_factories:
       - Grilled_Pork
       - Cooked_Beef
       - Cook_Salmon
-	  - Bastion_Rations
+      - Bastion_Rations
     repair_multiple: 2
     repair_inputs:
       Cooked Chicken:
@@ -1156,7 +1156,7 @@ production_factories:
       - Iron_XP_Bottle_1
       - Iron_XP_Bottle_2
       - Iron_XP_Bottle_3
-	  - Bastion_Smaragdus_Polisher
+      - Bastion_Smaragdus_Polisher
     repair_multiple: 20
     repair_inputs:
       Iron Ingot:
@@ -1739,7 +1739,7 @@ production_factories:
       - Craft_Trap_Doors
       - Craft_Item_Frames
       - Craft_Bookshelfs
-	  - Bastion_Framing
+      - Bastion_Framing
     repair_multiple: 10
     repair_inputs:
       Paper:
@@ -1772,7 +1772,7 @@ production_factories:
       - Smelt_Lapis_Lazuli_Ore
       - Smelt_Redstone_Ore
       - Smelt_Netherquartz_Ore
-	  - Bastion_Walls
+      - Bastion_Walls
     repair_multiple: 26
     repair_inputs:
       Lapis Lazuli:
@@ -1809,7 +1809,7 @@ production_factories:
       - Smelt_Iron_Ore
       - Smelt_Gold_Ore
       - Smelt_Diamond_Ore
-	  - Bastion_Base
+      - Bastion_Base
     repair_multiple: 10
     repair_inputs:
       Coal:
@@ -1841,7 +1841,7 @@ production_factories:
       - Smelt_Cracked_Stone_Brick
       - Smelt_Mossy_Stone_Brick
       - Smelt_Chiseled_Stone_Brick
-	  - Bastion_Flooring
+      - Bastion_Flooring
     repair_multiple: 26
     repair_inputs:
       Stone Brick:
@@ -1914,7 +1914,7 @@ production_factories:
     recipes:
       - Produce_TNT
       - Produce_Fire_Charges
-	  - Bastion_Silicon_Tetranitratobihydrotrioxycarbon
+      - Bastion_Silicon_Tetranitratobihydrotrioxycarbon
     repair_multiple: 10
     repair_inputs:
       Sulphur:
@@ -1941,7 +1941,7 @@ production_factories:
       - Forge_Buckets
       - Forge_Iron_Doors
       - Forge_Flint_And_Steel
-	  - Bastion_Gearbox
+      - Bastion_Gearbox
     repair_multiple: 10
     repair_inputs:
       IRON_INGOT:
@@ -2056,7 +2056,7 @@ production_factories:
       - Dye_Light_Blue_Stained_Glass_Pane
       - Dye_Red_Stained_Glass_Pane
       - Dye_Lime_Stained_Glass_Pane
-	  - Bastion_Objet_Dart
+	  _Objet_Dart
     repair_multiple: 2
     repair_inputs:
       Lapis Lazuli:
@@ -2351,7 +2351,7 @@ production_factories:
 	   display_name: Walls
 	   lore: An item used to create a Bastion Block
     recipes:
-      - Bastion_Block
+	   - Bastion_Block
     repair_multiple: 10
     repair_inputs:
 	  Pure Ice:

--- a/config.yml
+++ b/config.yml
@@ -2304,61 +2304,61 @@ production_factories:
         material: COAL
         durability: 1
     inputs:
-	  Silicon Tetranitratobihydrotrioxycarbon:
-	   material: FIREWORK_CHARGE
-	   amount: 1
-	   display_name: Silicon Tetranitratobihydrotrioxycarbon
-	   lore: An item used to create a Bastion Block
-	  Smaragdus:
-	   material: EMERALD
-	   amount: 1
-	   display_name: Smaragdus
-	   lore: An item used to create a Bastion Block
-	  Rations:
-	   material: MUSHROOM_SOUP
-	   amount: 1
-	   display_name: Rations
-	   lore: An item used to create a Bastion Block
-	  Flooring:
-	   material: CLAY_BRICK
-	   amount: 1
-	   display_name: Flooring
-	   lore: An item used to create a Bastion Block
-	  Framing:
-	   material: STICK
-	   amount: 1
-	   display_name: Framing
-	   lore: An item used to create a Bastion Block
-	  Object d'art:
-	   material: FLINT
-	   amount: 1
-	   display_name: Object d'art
-	   lore: An item used to create a Bastion Block
-	  Gearbox:
-	   material: WATCH
-	   amount: 1
-	   display_name: Gearbox
-	   lore: An item used to create a Bastion Block
-	  Base:
-	   material: IRON_INGOT
-	   amount: 1
-	   display_name: Base
-	   lore: An item used to create a Bastion Block
-	  Walls:
-	   material: INK_SACK
-	   amount: 1
-	   durablity: 4
-	   display_name: Walls
-	   lore: An item used to create a Bastion Block
+      Silicon Tetranitratobihydrotrioxycarbon:
+        material: FIREWORK_CHARGE
+        amount: 64
+        display_name: Silicon Tetranitratobihydrotrioxycarbon
+        lore: An item used to create a Bastion Block
+      Smaragdus:
+        material: EMERALD
+        amount: 64
+        display_name: Smaragdus
+        lore: An item used to create a Bastion Block
+      Flooring:
+        material: CLAY_BRICK
+        amount: 8
+        display_name: Flooring
+        lore: An item used to create a Bastion Block
+      Framing:
+        material: STICK
+        amount: 8
+        display_name: Framing
+        lore: An item used to create a Bastion Block
+      Gearbox:
+        material: WATCH
+        amount: 8
+        display_name: Gearbox
+        lore: An item used to create a Bastion Block
+      Base:
+        material: IRON_INGOT
+        amount: 8
+        display_name: Base
+        lore: An item used to create a Bastion Block
+      Walls:
+        material: INK_SACK
+        amount: 32
+        durablity: 4
+        display_name: Walls
+        lore: An item used to create a Bastion Block
     recipes:
-	   - Bastion_Block
-    repair_multiple: 10
+       - Bastion_Block
+    repair_multiple: 16
     repair_inputs:
-	  Pure Ice:
-	   material: QUARTZ
-	   amount: 1
-	   display_name: Pure Ice
-	   lore: An item used to repair the Bastion Factory
+      Pure Ice:
+        material: QUARTZ
+        amount: 1
+        display_name: Pure Ice
+        lore: An item used to repair the Bastion Factory
+      Silicon Tetranitratobihydrotrioxycarbon:
+        material: FIREWORK_CHARGE
+        amount: 1
+        display_name: Silicon Tetranitratobihydrotrioxycarbon
+        lore: An item used to create a Bastion Block
+      Smaragdus:
+        material: EMERALD
+        amount: 1
+        display_name: Smaragdus
+        lore: An item used to create a Bastion Block
 production_recipes:
   Wood_XP_Bottle_0:
     name: Brew XP Bottles  - 1
@@ -6616,32 +6616,32 @@ production_recipes:
   Bastion_Walls:
     name: Walls
     production_time: 2
-	inputs:
+    inputs:
       Lapis Ore:
         material: LAPIS_ORE 
         amount: 8
       Cracked Stone Brick:
         material: SMOOTH_BRICK
-        amount: 8
+        amount: 32
         durability: 2
-	outputs:
+    outputs:
       Walls:
         material: INK_SACK
-        amount: 1
+        amount: 4
         durablity: 4
         display_name: Walls
         lore: An item used to create a Bastion Block
   Bastion_Base:
     name: Base
     production_time: 2
-	inputs:
+    inputs:
       Diamond Ore:
         material: DIAMOND_ORE
         amount: 16
       Redstone Ore:
         material: REDSTONE ORE
-        amount: 4
-	outputs:
+        amount: 32
+    outputs:
       Base:
         material: IRON_INGOT
         amount: 1
@@ -6650,103 +6650,103 @@ production_recipes:
   Bastion_Gearbox
     name: Gearbox
     production_time: 2
-	inputs:
-      Iron Ingot:
-        material: IRON_IGNOT
+    inputs:
+      Iron Block:a
+        material: IRON_BLOCK
         amount: 4
       Gold Ore:
         material: GOLD_ORE
-        amount: 2
-	outputs:
+        amount: 8
+    outputs:
       Gearbox:
         material: WATCH
         amount: 1
         display_name: Gearbox
         lore: An item used to create a Bastion Block
-  Bastion_Object_Dart
-    name: Object d'art
+  Bastion_Objet_Dart
+    name: "Objet d'art"
     production_time: 2
-	inputs:      
-	  Lapis Lazuli:
+    inputs:      
+      Lapis Lazuli:
         material: INK_SACK
-        amount: 1
+        amount: 16
         durability: 4
       Gray Dye:
         material: INK_SACK
-        amount: 1
+        amount: 16
         durability: 8
       Cocoa:
         material: INK_SACK
-        amount: 1
+        amount: 16
         durability: 3
       Purple Dye:
         material: INK_SACK
-        amount: 1
+        amount: 16
         durability: 5
       Dandelion Yellow:
         material: INK_SACK
-        amount: 1
+        amount: 16
         durability: 11
       Ink Sack:
         material: INK_SACK
-        amount: 1
+        amount: 16
       Magenta Dye:
         material: INK_SACK
-        amount: 1
+        amount: 16
         durability: 13
       Pink Dye:
         material: INK_SACK
-        amount: 1
+        amount: 16
         durability: 9
       Cyan Dye:
         material: INK_SACK
-        amount: 1
+        amount: 16
         durability: 6
       Orange Dye:
         material: INK_SACK
-        amount: 1
+        amount: 16
         durability: 14
       Cactus Green:
         material: INK_SACK
-        amount: 1
+        amount: 16
         durability: 2
       Bone Meal:
         material: INK_SACK
-        amount: 1
+        amount: 16
         durability: 15
       Light Gray Dye:
         material: INK_SACK
-        amount: 1
+        amount: 16
         durability: 7
       Light Blue Dye:
         material: INK_SACK
-        amount: 1
+        amount: 16
         durability: 12
       Rose Red:
         material: INK_SACK
-        amount: 1
+        amount: 16
         durability: 1
       Lime Dye:
         material: INK_SACK
-        amount: 1
+        amount: 16
         durability: 10
       Red Sand:
         material: SAND
-        amount: 64
+        amount: 256
         durability: 1
     outputs:
-      Object d'art:
+      "Objet d'art":
         material: FLINT
         amount: 1
-        display_name: Object d'art
+        display_name: "Objet d'art"
         lore: An item used to create a Bastion Block
   Bastion_Framing:
     inputs:
       Chest:
         material: CHEST
-        amount: 8
-      Iron Ignot:
-        material: IRON_IGNOT
+        amount: 64
+      Iron Block:
+        material: IRON_BLOCK
         amount: 4
     outputs:
       Framing:
@@ -6757,11 +6757,11 @@ production_recipes:
   Bastion_Flooring:
     inputs:
       Clay Ball:
-        material: CALL_BALL
-        amount: 4
+        material: CLAY_BALL
+        amount: 32
       Nether Brick:
         material: NETHER_BRICK
-        amount: 64        
+        amount: 64
     outputs:
       Flooring:
         material: CLAY_BRICK
@@ -6772,25 +6772,26 @@ production_recipes:
     inputs:
       Wheat:
         meterial: WHEAT
-        amount: 32
+        amount: 256
       Bowl:
         meterial: BOWL
-        amount: 4
+        amount: 32
     outputs:
       Rations:
         material: MUSHROOM_SOUP
-        amount: 1
+        amount: 32
         display_name: Rations
         lore: An item used to create a Bastion Block
   Bastion_Smaragdus_Polisher:
+    production_time: 32
     inputs:
       Emerald Block:
         material: EMERALD_BLOCK
-        amount: 1
+        amount: 16
     outputs:
       Smaragdus:
         material: EMERALD
-        amount: 1
+        amount: 16
         display_name: Smaragdus
         lore: An item used to create a Bastion Block
   Bastion_Silicon_Tetranitratobihydrotrioxycarbon:
@@ -6814,38 +6815,38 @@ production_recipes:
     outputs:
       Silicon Tetranitratobihydrotrioxycarbon:
         material: FIREWORK_CHARGE
-        amount: 1
+        amount: 8
         display_name: Silicon Tetranitratobihydrotrioxycarbon
         lore: An item used to create a Bastion Block
   Bastion_Pure_Ice:
     inputs:
       Compact Ice:
         material: COMPACT_ICE
-        amount: 64
+        amount: 512
       Leather:
         material: LEATHER
-        amount: 4
+        amount: 32
     outputs:
       Pure Ice:
         material: QUARTZ
-        amount: 1
+        amount: 8
         display_name: Pure Ice
         lore: An item used to repair the Bastion Factory
   Bastion_Factory:
     inputs:
       Silicon Tetranitratobihydrotrioxycarbon:
         material: FIREWORK_CHARGE
-        amount: 1
+        amount: 16
         display_name: Silicon Tetranitratobihydrotrioxycarbon
        lore: An item used to create a Bastion Block
       Smaragdus:
         material: EMERALD
-        amount: 1
+        amount: 2
         display_name: Smaragdus
         lore: An item used to create a Bastion Block
       Rations:
         material: MUSHROOM_SOUP
-        amount: 1
+        amount: 16
         display_name: Rations
         lore: An item used to create a Bastion Block
       Flooring:
@@ -6858,10 +6859,10 @@ production_recipes:
         amount: 1
         display_name: Framing
         lore: An item used to create a Bastion Block
-      Object d'art:
+      "Objet d'art":
         material: FLINT
         amount: 1
-        display_name: Object d'art
+        display_name: "Objet d'art"
         lore: An item used to create a Bastion Block
       Gearbox:
         material: WATCH
@@ -6875,12 +6876,12 @@ production_recipes:
         lore: An item used to create a Bastion Block
       Walls:
         material: INK_SACK
-        amount: 1
+        amount: 4
         durablity: 4
         display_name: Walls
         lore: An item used to create a Bastion Block
     outputs:
       Sponge:
         material: SPONGE
-        amount: 64     
-	   
+        amount: 32
+       

--- a/config.yml
+++ b/config.yml
@@ -6614,8 +6614,8 @@ production_recipes:
         material: PACKED_ICE
         amount: 576
   Bastion_Walls:
-	name: Walls
-	production_time: 2
+    name: Walls
+    production_time: 2
 	inputs:
       Lapis Ore:
         material: LAPIS_ORE 
@@ -6632,8 +6632,8 @@ production_recipes:
         display_name: Walls
         lore: An item used to create a Bastion Block
   Bastion_Base:
-	name: Base
-	production_time: 2
+    name: Base
+    production_time: 2
 	inputs:
       Diamond Ore:
         material: DIAMOND_ORE
@@ -6649,7 +6649,7 @@ production_recipes:
         lore: An item used to create a Bastion Block
   Bastion_Gearbox
     name: Gearbox
-	production_time: 2
+    production_time: 2
 	inputs:
       Iron Ingot:
         material: IRON_IGNOT
@@ -6665,7 +6665,7 @@ production_recipes:
         lore: An item used to create a Bastion Block
   Bastion_Object_Dart
     name: Object d'art
-	production_time: 2
+    production_time: 2
 	inputs:      
 	  Lapis Lazuli:
         material: INK_SACK

--- a/config.yml
+++ b/config.yml
@@ -6617,15 +6617,15 @@ production_recipes:
 	name: Walls
 	production_time: 2
 	inputs:
-	  Lapis Ore:
+      Lapis Ore:
         material: LAPIS_ORE 
         amount: 8
-	  Cracked Stone Brick:
+      Cracked Stone Brick:
         material: SMOOTH_BRICK
         amount: 8
         durability: 2
 	outputs:
-	  Walls:
+      Walls:
         material: INK_SACK
         amount: 1
         durablity: 4
@@ -6635,34 +6635,34 @@ production_recipes:
 	name: Base
 	production_time: 2
 	inputs:
-	  Diamond Ore:
+      Diamond Ore:
         material: DIAMOND_ORE
         amount: 16
-	  Redstone Ore:
+      Redstone Ore:
         material: REDSTONE ORE
         amount: 4
 	outputs:
-	  Base:
-	   material: IRON_INGOT
-	   amount: 1
-	   display_name: Base
-	   lore: An item used to create a Bastion Block
+      Base:
+        material: IRON_INGOT
+        amount: 1
+        display_name: Base
+        lore: An item used to create a Bastion Block
   Bastion_Gearbox
     name: Gearbox
 	production_time: 2
 	inputs:
-	  Iron Ingot:
+      Iron Ingot:
         material: IRON_IGNOT
         amount: 4
-	  Gold Ore:
+      Gold Ore:
         material: GOLD_ORE
         amount: 2
 	outputs:
-	  Gearbox:
-	   material: WATCH
-	   amount: 1
-	   display_name: Gearbox
-	   lore: An item used to create a Bastion Block
+      Gearbox:
+        material: WATCH
+        amount: 1
+        display_name: Gearbox
+        lore: An item used to create a Bastion Block
   Bastion_Object_Dart
     name: Object d'art
 	production_time: 2

--- a/config.yml
+++ b/config.yml
@@ -6621,12 +6621,12 @@ production_recipes:
         material: LAPIS_ORE 
         amount: 8
 	  Cracked Stone Brick:
-	    material: SMOOTH_BRICK
+        material: SMOOTH_BRICK
         amount: 8
         durability: 2
 	outputs:
 	  Walls:
-	    material: INK_SACK
+        material: INK_SACK
         amount: 1
         durablity: 4
         display_name: Walls
@@ -6636,10 +6636,10 @@ production_recipes:
 	production_time: 2
 	inputs:
 	  Diamond Ore:
-	    material: DIAMOND_ORE
+        material: DIAMOND_ORE
         amount: 16
 	  Redstone Ore:
-	    material: REDSTONE ORE
+        material: REDSTONE ORE
         amount: 4
 	outputs:
 	  Base:
@@ -6652,10 +6652,10 @@ production_recipes:
 	production_time: 2
 	inputs:
 	  Iron Ingot:
-	    material: IRON_IGNOT
+        material: IRON_IGNOT
         amount: 4
 	  Gold Ore:
-	    material: GOLD_ORE
+        material: GOLD_ORE
         amount: 2
 	outputs:
 	  Gearbox:
@@ -6731,7 +6731,7 @@ production_recipes:
         amount: 1
         durability: 10
 	  Red Sand:
-	    material: SAND
+        material: SAND
         amount: 64
         durability: 1
 	outputs:
@@ -6743,10 +6743,10 @@ production_recipes:
   Bastion_Framing:
     inputs:
 	  Chest:
-	    material: CHEST
+        material: CHEST
         amount: 8
 	  Iron Ignot:
-	    material: IRON_IGNOT
+        material: IRON_IGNOT
         amount: 4
 	outputs:
 	  Framing:

--- a/config.yml
+++ b/config.yml
@@ -6730,109 +6730,109 @@ production_recipes:
         material: INK_SACK
         amount: 1
         durability: 10
-	  Red Sand:
+      Red Sand:
         material: SAND
         amount: 64
         durability: 1
-	outputs:
-	  Object d'art:
-	   material: FLINT
-	   amount: 1
-	   display_name: Object d'art
-	   lore: An item used to create a Bastion Block
+    outputs:
+      Object d'art:
+        material: FLINT
+        amount: 1
+        display_name: Object d'art
+        lore: An item used to create a Bastion Block
   Bastion_Framing:
     inputs:
-	  Chest:
+      Chest:
         material: CHEST
         amount: 8
-	  Iron Ignot:
+      Iron Ignot:
         material: IRON_IGNOT
         amount: 4
-	outputs:
-	  Framing:
-	   material: STICK
-	   amount: 1
-	   display_name: Framing
-	   lore: An item used to create a Bastion Block
+    outputs:
+      Framing:
+        material: STICK
+        amount: 1
+        display_name: Framing
+        lore: An item used to create a Bastion Block
   Bastion_Flooring:
     inputs:
-	  Clay Ball:
-	   material: CALL_BALL
-	   amount: 4
-	  Nether Brick:
-	   material: NETHER_BRICK
-	   amount: 64        
-	outputs:
-	  Flooring:
-	   material: CLAY_BRICK
-	   amount: 1
-	   display_name: Flooring
-	   lore: An item used to create a Bastion Block
+      Clay Ball:
+        material: CALL_BALL
+        amount: 4
+      Nether Brick:
+        material: NETHER_BRICK
+        amount: 64        
+    outputs:
+      Flooring:
+        material: CLAY_BRICK
+        amount: 1
+        display_name: Flooring
+        lore: An item used to create a Bastion Block
   Bastion_Rations:
     inputs:
-	  Wheat:
-	   meterial: WHEAT
-	   amount: 32
-	  Bowl:
-	   meterial: BOWL
-	   amount: 4
-	outputs:
-	  Rations:
-	   material: MUSHROOM_SOUP
-	   amount: 1
-	   display_name: Rations
-	   lore: An item used to create a Bastion Block
+      Wheat:
+        meterial: WHEAT
+        amount: 32
+      Bowl:
+        meterial: BOWL
+        amount: 4
+    outputs:
+      Rations:
+        material: MUSHROOM_SOUP
+        amount: 1
+        display_name: Rations
+        lore: An item used to create a Bastion Block
   Bastion_Smaragdus_Polisher:
-	inputs:
-	  Emerald Block:
-	   material: EMERALD_BLOCK
-	   amount: 1
-	outputs:
-	  Smaragdus:
-	   material: EMERALD
-	   amount: 1
-	   display_name: Smaragdus
-	   lore: An item used to create a Bastion Block
+    inputs:
+      Emerald Block:
+        material: EMERALD_BLOCK
+        amount: 1
+    outputs:
+      Smaragdus:
+        material: EMERALD
+        amount: 1
+        display_name: Smaragdus
+        lore: An item used to create a Bastion Block
   Bastion_Silicon_Tetranitratobihydrotrioxycarbon:
     inputs:
-	  Sulphur:
-	   material: SULPHUR
-	   amount: 8
-	  Quartz:
-       material: QUARTZ
-	   amount: 32
-	  Podzol:
-	   material: DIRT
-	   amount: 32
-	   durability: 3
-	  Coal Block:
-	   material: COAL_BLOCK
-	   amount: 8
-	  Water Bucket:
-	   material: WATER_BUCKET
-	   amount: 2
-	outputs:
-	  Silicon Tetranitratobihydrotrioxycarbon:
-	   material: FIREWORK_CHARGE
-	   amount: 1
-	   display_name: Silicon Tetranitratobihydrotrioxycarbon
-	   lore: An item used to create a Bastion Block
+      Sulphur:
+        material: SULPHUR
+        amount: 8
+      Quartz:
+        material: QUARTZ
+        amount: 32
+      Podzol:
+        material: DIRT
+        amount: 32
+        durability: 3
+      Coal Block:
+        material: COAL_BLOCK
+        amount: 8
+      Water Bucket:
+        material: WATER_BUCKET
+        amount: 2
+    outputs:
+      Silicon Tetranitratobihydrotrioxycarbon:
+        material: FIREWORK_CHARGE
+        amount: 1
+        display_name: Silicon Tetranitratobihydrotrioxycarbon
+        lore: An item used to create a Bastion Block
   Bastion_Pure_Ice:
     inputs:
-	  Compact Ice:
-	   material: COMPACT_ICE
-	   amount: 64
-	  Leather:
-	   material: LEATHER
-	   amount: 4
-	outputs:
-	  Pure Ice:
-	   material: QUARTZ
-	   amount: 1
-	   display_name: Pure Ice
-	   lore: An item used to repair the Bastion Factory
+      Compact Ice:
+        material: COMPACT_ICE
+        amount: 64
+      Leather:
+        material: LEATHER
+        amount: 4
+    outputs:
+      Pure Ice:
+        material: QUARTZ
+        amount: 1
+        display_name: Pure Ice
+        lore: An item used to repair the Bastion Factory
   Bastion_Factory:
-      inputs:
+    inputs:
       Silicon Tetranitratobihydrotrioxycarbon:
         material: FIREWORK_CHARGE
         amount: 1
@@ -6881,6 +6881,6 @@ production_recipes:
         lore: An item used to create a Bastion Block
     outputs:
       Sponge:
-      material: SPONGE
-      amount: 64     
+        material: SPONGE
+        amount: 64     
 	   

--- a/config.yml
+++ b/config.yml
@@ -1092,6 +1092,7 @@ production_factories:
       - Grilled_Pork
       - Cooked_Beef
       - Cook_Salmon
+	  - Bastion_Rations
     repair_multiple: 2
     repair_inputs:
       Cooked Chicken:
@@ -1155,6 +1156,7 @@ production_factories:
       - Iron_XP_Bottle_1
       - Iron_XP_Bottle_2
       - Iron_XP_Bottle_3
+	  - Bastion_Smaragdus_Polisher
     repair_multiple: 20
     repair_inputs:
       Iron Ingot:
@@ -1737,6 +1739,7 @@ production_factories:
       - Craft_Trap_Doors
       - Craft_Item_Frames
       - Craft_Bookshelfs
+	  - Bastion_Framing
     repair_multiple: 10
     repair_inputs:
       Paper:
@@ -1769,6 +1772,7 @@ production_factories:
       - Smelt_Lapis_Lazuli_Ore
       - Smelt_Redstone_Ore
       - Smelt_Netherquartz_Ore
+	  - Bastion_Walls
     repair_multiple: 26
     repair_inputs:
       Lapis Lazuli:
@@ -1805,6 +1809,7 @@ production_factories:
       - Smelt_Iron_Ore
       - Smelt_Gold_Ore
       - Smelt_Diamond_Ore
+	  - Bastion_Base
     repair_multiple: 10
     repair_inputs:
       Coal:
@@ -1836,6 +1841,7 @@ production_factories:
       - Smelt_Cracked_Stone_Brick
       - Smelt_Mossy_Stone_Brick
       - Smelt_Chiseled_Stone_Brick
+	  - Bastion_Flooring
     repair_multiple: 26
     repair_inputs:
       Stone Brick:
@@ -1908,6 +1914,7 @@ production_factories:
     recipes:
       - Produce_TNT
       - Produce_Fire_Charges
+	  - Bastion_Silicon_Tetranitratobihydrotrioxycarbon
     repair_multiple: 10
     repair_inputs:
       Sulphur:
@@ -1934,6 +1941,7 @@ production_factories:
       - Forge_Buckets
       - Forge_Iron_Doors
       - Forge_Flint_And_Steel
+	  - Bastion_Gearbox
     repair_multiple: 10
     repair_inputs:
       IRON_INGOT:
@@ -2048,6 +2056,7 @@ production_factories:
       - Dye_Light_Blue_Stained_Glass_Pane
       - Dye_Red_Stained_Glass_Pane
       - Dye_Lime_Stained_Glass_Pane
+	  - Bastion_Objet_Dart
     repair_multiple: 2
     repair_inputs:
       Lapis Lazuli:
@@ -2288,6 +2297,68 @@ production_factories:
     repair_inputs:
       Stick:
         material: STICK
+  Bastion_Factory:
+    name: Bastion Factory
+    fuel:
+      Charcoal:
+        material: COAL
+        durability: 1
+    inputs:
+	  Silicon Tetranitratobihydrotrioxycarbon:
+	   material: FIREWORK_CHARGE
+	   amount: 1
+	   display_name: Silicon Tetranitratobihydrotrioxycarbon
+	   lore: An item used to create a Bastion Block
+	  Smaragdus:
+	   material: EMERALD
+	   amount: 1
+	   display_name: Smaragdus
+	   lore: An item used to create a Bastion Block
+	  Rations:
+	   material: MUSHROOM_SOUP
+	   amount: 1
+	   display_name: Rations
+	   lore: An item used to create a Bastion Block
+	  Flooring:
+	   material: CLAY_BRICK
+	   amount: 1
+	   display_name: Flooring
+	   lore: An item used to create a Bastion Block
+	  Framing:
+	   material: STICK
+	   amount: 1
+	   display_name: Framing
+	   lore: An item used to create a Bastion Block
+	  Object d'art:
+	   material: FLINT
+	   amount: 1
+	   display_name: Object d'art
+	   lore: An item used to create a Bastion Block
+	  Gearbox:
+	   material: WATCH
+	   amount: 1
+	   display_name: Gearbox
+	   lore: An item used to create a Bastion Block
+	  Base:
+	   material: IRON_INGOT
+	   amount: 1
+	   display_name: Base
+	   lore: An item used to create a Bastion Block
+	  Walls:
+	   material: INK_SACK
+	   amount: 1
+	   durablity: 4
+	   display_name: Walls
+	   lore: An item used to create a Bastion Block
+    recipes:
+      - Bastion_Block
+    repair_multiple: 10
+    repair_inputs:
+	  Pure Ice:
+	   material: QUARTZ
+	   amount: 1
+	   display_name: Pure Ice
+	   lore: An item used to repair the Bastion Factory
 production_recipes:
   Wood_XP_Bottle_0:
     name: Brew XP Bottles  - 1
@@ -6542,4 +6613,274 @@ production_recipes:
       Packed_Ice:
         material: PACKED_ICE
         amount: 576
-
+  Bastion_Walls:
+	name: Walls
+	production_time: 2
+	inputs:
+	  Lapis Ore:
+        material: LAPIS_ORE 
+        amount: 8
+	  Cracked Stone Brick:
+	    material: SMOOTH_BRICK
+		amount: 8
+        durability: 2
+	outputs:
+	  Walls:
+	    material: INK_SACK
+		amount: 1
+		durablity: 4
+		display_name: Walls
+		lore: An item used to create a Bastion Block
+  Bastion_Base:
+	name: Base
+	production_time: 2
+	inputs:
+	  Diamond Ore:
+	    material: DIAMOND_ORE
+		amount: 16
+	  Redstone Ore:
+	    material: REDSTONE ORE
+		amount: 4
+	outputs:
+	  Base:
+	   material: IRON_INGOT
+	   amount: 1
+	   display_name: Base
+	   lore: An item used to create a Bastion Block
+  Bastion_Gearbox
+    name: Gearbox
+	production_time: 2
+	inputs:
+	  Iron Ingot:
+	    material: IRON_IGNOT
+		amount: 4
+	  Gold Ore:
+	    material: GOLD_ORE
+		amount: 2
+	outputs:
+	  Gearbox:
+	   material: WATCH
+	   amount: 1
+	   display_name: Gearbox
+	   lore: An item used to create a Bastion Block
+  Bastion_Object_Dart
+    name: Object d'art
+	production_time: 2
+	inputs:      
+	  Lapis Lazuli:
+        material: INK_SACK
+        amount: 1
+        durability: 4
+      Gray Dye:
+        material: INK_SACK
+        amount: 1
+        durability: 8
+      Cocoa:
+        material: INK_SACK
+        amount: 1
+        durability: 3
+      Purple Dye:
+        material: INK_SACK
+        amount: 1
+        durability: 5
+      Dandelion Yellow:
+        material: INK_SACK
+        amount: 1
+        durability: 11
+      Ink Sack:
+        material: INK_SACK
+        amount: 1
+      Magenta Dye:
+        material: INK_SACK
+        amount: 1
+        durability: 13
+      Pink Dye:
+        material: INK_SACK
+        amount: 1
+        durability: 9
+      Cyan Dye:
+        material: INK_SACK
+        amount: 1
+        durability: 6
+      Orange Dye:
+        material: INK_SACK
+        amount: 1
+        durability: 14
+      Cactus Green:
+        material: INK_SACK
+        amount: 1
+        durability: 2
+      Bone Meal:
+        material: INK_SACK
+        amount: 1
+        durability: 15
+      Light Gray Dye:
+        material: INK_SACK
+        amount: 1
+        durability: 7
+      Light Blue Dye:
+        material: INK_SACK
+        amount: 1
+        durability: 12
+      Rose Red:
+        material: INK_SACK
+        amount: 1
+        durability: 1
+      Lime Dye:
+        material: INK_SACK
+        amount: 1
+        durability: 10
+	  Red Sand:
+	    material: SAND
+		amount: 64
+		durability: 1
+	outputs:
+	  Object d'art:
+	   material: FLINT
+	   amount: 1
+	   display_name: Object d'art
+	   lore: An item used to create a Bastion Block
+  Bastion_Framing:
+    inputs:
+	  Chest:
+	    material: CHEST
+		amount: 8
+	  Iron Ignot:
+	    material: IRON_IGNOT
+		amount: 4
+	outputs:
+	  Framing:
+	   material: STICK
+	   amount: 1
+	   display_name: Framing
+	   lore: An item used to create a Bastion Block
+  Bastion_Flooring:
+    inputs:
+	  Clay Ball:
+	   material: CALL_BALL
+	   amount: 4
+	  Nether Brick:
+	   material: NETHER_BRICK
+	   amount: 64		
+	outputs:
+	  Flooring:
+	   material: CLAY_BRICK
+	   amount: 1
+	   display_name: Flooring
+	   lore: An item used to create a Bastion Block
+  Bastion_Rations:
+    inputs:
+	  Wheat:
+	   meterial: WHEAT
+	   amount: 32
+	  Bowl:
+	   meterial: BOWL
+	   amount: 4
+	outputs:
+	  Rations:
+	   material: MUSHROOM_SOUP
+	   amount: 1
+	   display_name: Rations
+	   lore: An item used to create a Bastion Block
+  Bastion_Smaragdus_Polisher:
+	inputs:
+	  Emerald Block:
+	   material: EMERALD_BLOCK
+	   amount: 1
+	outputs:
+	  Smaragdus:
+	   material: EMERALD
+	   amount: 1
+	   display_name: Smaragdus
+	   lore: An item used to create a Bastion Block
+  Bastion_Silicon_Tetranitratobihydrotrioxycarbon:
+    inputs:
+	  Sulphur:
+	   material: SULPHUR
+	   amount: 8
+	  Quartz:
+       material: QUARTZ
+	   amount: 32
+	  Podzol:
+	   material: DIRT
+	   amount: 32
+	   durability: 3
+	  Coal Block:
+	   material: COAL_BLOCK
+	   amount: 8
+	  Water Bucket:
+	   material: WATER_BUCKET
+	   amount: 2
+	outputs:
+	  Silicon Tetranitratobihydrotrioxycarbon:
+	   material: FIREWORK_CHARGE
+	   amount: 1
+	   display_name: Silicon Tetranitratobihydrotrioxycarbon
+	   lore: An item used to create a Bastion Block
+  Bastion_Pure_Ice:
+    inputs:
+	  Compact Ice:
+	   material: COMPACT_ICE
+	   amount: 64
+	  Leather:
+	   material: LEATHER
+	   amount: 4
+	outputs:
+	  Pure Ice:
+	   material: QUARTZ
+	   amount: 1
+	   display_name: Pure Ice
+	   lore: An item used to repair the Bastion Factory
+  Bastion_Factory:
+      inputs:
+      Silicon Tetranitratobihydrotrioxycarbon:
+        material: FIREWORK_CHARGE
+        amount: 1
+        display_name: Silicon Tetranitratobihydrotrioxycarbon
+       lore: An item used to create a Bastion Block
+      Smaragdus:
+        material: EMERALD
+        amount: 1
+        display_name: Smaragdus
+        lore: An item used to create a Bastion Block
+      Rations:
+        material: MUSHROOM_SOUP
+        amount: 1
+        display_name: Rations
+        lore: An item used to create a Bastion Block
+      Flooring:
+        material: CLAY_BRICK
+        amount: 1
+        display_name: Flooring
+        lore: An item used to create a Bastion Block
+      Framing:
+        material: STICK
+        amount: 1
+        display_name: Framing
+        lore: An item used to create a Bastion Block
+      Object d'art:
+        material: FLINT
+        amount: 1
+        display_name: Object d'art
+        lore: An item used to create a Bastion Block
+      Gearbox:
+        material: WATCH
+        amount: 1
+        display_name: Gearbox
+        lore: An item used to create a Bastion Block
+      Base:
+        material: IRON_INGOT
+        amount: 1
+        display_name: Base
+        lore: An item used to create a Bastion Block
+      Walls:
+        material: INK_SACK
+        amount: 1
+        durablity: 4
+        display_name: Walls
+        lore: An item used to create a Bastion Block
+    outputs:
+      Sponge:
+      material: SPONGE
+      amount: 64     
+	   


### PR DESCRIPTION
Amended Ribagi's system with higher costs, especially increasing the costs of construction and maintenance. Added extra costs to repair, removed some from each of construction and use so that they differ a bit (have to plan for costs to run before building if you want to be effective). Also, fixed some indentation, couple of typos, and it's "objet d'art", not "object d'art". Substantial test recommended.

**Add to Fancy Ore Smelter**

```
    4 Walls for 8 Lapis ore, 32 smooth brick
```

**Add to Ore Smelter**

```
    1 Base for 16 Diamond ore, 32 redstone ore
```

**Add to Iron Forge**

```
    1 Gearbox for 4 Iron blocks, 8 gold ore
```

**Add to Stained Glass Factory**

```
    1 Objet d'art for 16 of each dye, 256 red sand
```

**Add to Carpentry Factory**

```
    1 Framing for 64 Chests, 4 iron blocks
```

**Add to Stone Brick Smelter**

```
    1 Flooring for 64 Nether Brick, 32 clay ball
```

**Add to Grill**

```
    32 Rations for 256 Wheat, 32 bowls
```

**Add to Iron Cauldron**

```
    16 Smaragdus for 16 Emerald block (slow - 32 charcoal)
```

**Add to Explosives Factory**

```
    8 Silicon Tetranitratobihydrotrioxycarbon for 8 gunpowder, 32 quartz, 32 dirt, 8 coal block, 2 water buckets
```

**Add to Crystallization Factory**

```
    8 Pure ice for 512 Compact ice, 32 leather
```

**Bastion Factory** - 64 Silicon Tetranitratobihydrotrioxycarbon, 64 Smaragdus, 8 Flooring, 8 Framing, 8 Gearbox, 8 Base, 32 Walls

```
    Full repair for 16 Pure ice, 16 Silicon Tetranitratobihydrotrioxycarbon, 16 Smaragdus

32 Bastions (sponges) for 16 Silicon Tetranitratobihydrotrioxycarbon, 2 Smaragdus, 16 Rations, 1 Flooring, 1 Framing, 1 Objet d'art, 1 Gearbox, 1 Base, 4 Walls
```

Total raw materials in construction: 64 gunpowder, 256 quartz, 256 dirt, 64 coal block, 16 water buckets, 64 emerald blocks, 512 chests, 64 iron blocks, 512 nether brick, 256 clay ball, 64 gold ore, 128 diamond ore, 256 redstone ore, 64 lapis ore, 256 smooth brick

Total raw materials per full repair: 1024 packed ice, 64 leather, 16 gunpowder, 64 quartz, 64 dirt, 16 coal blocks, 4 water buckets, 16 emerald blocks

Total raw materials per run: 16 gunpowder, 64 quartz, 64 dirt, 16 coal blocks, 4 water buckets, 2 emerald blocks, 128 wheat, 16 bowls, 64 nether brick, 32 clay ball, 64 chests, 8 iron blocks, 16 of each dye, 256 red sand, 8 gold ore, 16 diamond ore, 32 redstone ore, 8 lapis ore, 32 smooth brick

Total raw materials per bastion: 1/2 gunpowder, 2 quartz, 2 dirt, 1/4 coal blocks, 1/8 water buckets, 1/16 emerald blocks, 4 wheat, 1/2 bowls, 2 nether brick, 1 clay ball, 2 chests, 1/4 iron blocks, 1/2 of each dye, 8 red sand, 1/4 gold ore, 1/2 diamond ore, 1 redstone ore, 1/4 lapis ore, 1 smooth brick

So the goal of having the factory expensive and the bastions effective to sell seems plausible.
