### PR TITLE
Mad Scientist Lab - Fix shears name

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1921,7 +1921,7 @@ production_factories:
         durability: 100
         amount: 16
       Silk touch shears:
-        material: SILK_TOUCH
+        material: SHEARS
         amount: 1
         repair_cost: 2
         enchantments:


### PR DESCRIPTION
Wrong item name for the silk touch shears, making the  not require these on Civtest (in fact fails with them). Had corrected in a local test but not pushed properly, fix here.
