### PR TITLE
Bastion Factory Update and Fixes

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -7084,3 +7084,4 @@ production_recipes:
         material: SPONGE
         amount: 32
         display_name: Bastion
+        

--- a/config.yml
+++ b/config.yml
@@ -2007,7 +2007,7 @@ production_factories:
     repair_multiple: 10
     repair_inputs:
       IRON_INGOT:
-        material: Iron Ingot
+        material: IRON_INGOT
         amount: 12
   Stained_Glass_Processing:
     name: Stained Glass Processing
@@ -2190,6 +2190,7 @@ production_factories:
         durability: 1
     recipes:
       - Compact_Ice
+      - Bastion_Pure_Ice
     repair_multiple: 10
     repair_inputs:
       Ice:
@@ -6843,7 +6844,7 @@ production_recipes:
     name: Gearbox
     production_time: 2
     inputs:
-      Iron Block:
+      Iron Block:a
         material: IRON_BLOCK
         amount: 4
       Gold Ore:
@@ -6856,7 +6857,7 @@ production_recipes:
         display_name: Gearbox
         lore: An item used to create a Bastion Block
   Bastion_Objet_Dart:
-    name: "Objet d'art"
+    name: Objet d'art
     production_time: 2
     inputs:      
       Lapis Lazuli:
@@ -6927,12 +6928,13 @@ production_recipes:
         amount: 256
         durability: 1
     outputs:
-      "Objet d'art":
+      Objet d'art:
         material: FLINT
         amount: 1
-        display_name: "Objet d'art"
+        display_name: Objet d'art
         lore: An item used to create a Bastion Block
   Bastion_Framing:
+    name: Framing
     inputs:
       Chest:
         material: CHEST
@@ -6947,6 +6949,7 @@ production_recipes:
         display_name: Framing
         lore: An item used to create a Bastion Block
   Bastion_Flooring:
+    name: Flooring
     inputs:
       Clay Ball:
         material: CLAY_BALL
@@ -6961,12 +6964,13 @@ production_recipes:
         display_name: Flooring
         lore: An item used to create a Bastion Block
   Bastion_Rations:
+    name: Rations
     inputs:
       Wheat:
-        meterial: WHEAT
+        material: WHEAT
         amount: 256
       Bowl:
-        meterial: BOWL
+        material: BOWL
         amount: 32
     outputs:
       Rations:
@@ -6975,6 +6979,7 @@ production_recipes:
         display_name: Rations
         lore: An item used to create a Bastion Block
   Bastion_Smaragdus_Polisher:
+    name: Smaragdus
     production_time: 32
     inputs:
       Emerald Block:
@@ -6987,6 +6992,7 @@ production_recipes:
         display_name: Smaragdus
         lore: An item used to create a Bastion Block
   Bastion_Silicon_Tetranitratobihydrotrioxycarbon:
+    name: Silicon_Tetranitratobihydrotrioxycarbon
     inputs:
       Sulphur:
         material: SULPHUR
@@ -6997,7 +7003,7 @@ production_recipes:
       Podzol:
         material: DIRT
         amount: 32
-        durability: 3
+        durability: 2
       Coal Block:
         material: COAL_BLOCK
         amount: 8
@@ -7011,6 +7017,7 @@ production_recipes:
         display_name: Silicon Tetranitratobihydrotrioxycarbon
         lore: An item used to create a Bastion Block
   Bastion_Pure_Ice:
+    name: Pure Ice
     inputs:
       Compact Ice:
         material: COMPACT_ICE
@@ -7030,7 +7037,7 @@ production_recipes:
         material: FIREWORK_CHARGE
         amount: 16
         display_name: Silicon Tetranitratobihydrotrioxycarbon
-        lore: An item used to create a Bastion Block
+       lore: An item used to create a Bastion Block
       Smaragdus:
         material: EMERALD
         amount: 2
@@ -7051,10 +7058,10 @@ production_recipes:
         amount: 1
         display_name: Framing
         lore: An item used to create a Bastion Block
-      "Objet d'art":
+      Objet d'art:
         material: FLINT
         amount: 1
-        display_name: "Objet d'art"
+        display_name: Objet d'art
         lore: An item used to create a Bastion Block
       Gearbox:
         material: WATCH
@@ -7073,7 +7080,8 @@ production_recipes:
         display_name: Walls
         lore: An item used to create a Bastion Block
     outputs:
-      Sponge:
+      Bastion:
         material: SPONGE
         amount: 32
+        display name: Bastion
        

--- a/config.yml
+++ b/config.yml
@@ -7084,4 +7084,3 @@ production_recipes:
         material: SPONGE
         amount: 32
         display name: Bastion
-       

--- a/config.yml
+++ b/config.yml
@@ -7083,4 +7083,4 @@ production_recipes:
       Bastion:
         material: SPONGE
         amount: 32
-        display name: Bastion
+        display_name: Bastion


### PR DESCRIPTION
Side-update: including the IRON_INGOT fix on line 2010.
- Fixed Podzol for Silicon_Tetranitratobihydrotrioxycarbon (incorrect state listed, leaving recipe impossible)
- Changed 'Sponge' to 'Bastion' for Bastion Factory (Do we want a lore attached to this as well that describes the Bastion block?)
- Fixed Typo 'Meterial' breaking the input for Rations
- Added Pure Ice recipe to Crystallization Factory
- Added names for 'Default Name' recipes
- Removed air quotes from "Objet d'art"
