### PR TITLE
Ink Sack durability fix

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -7036,6 +7036,7 @@ production_recipes:
       Ink Sack:
         material: INK_SACK
         amount: 16
+        durability: 0
       Magenta Dye:
         material: INK_SACK
         amount: 16

--- a/config.yml
+++ b/config.yml
@@ -7230,7 +7230,7 @@ production_recipes:
       Walls:
         material: INK_SACK
         amount: 4
-        durability: 4
+        durability: 0
         display_name: Walls
         lore: An item used to create a Bastion Block
     outputs:


### PR DESCRIPTION
- An incorrect durability value @7234 for the Ink Sack 'Walls' renders the Bastion factory temporarily unable to be created.
- Additionally, the Ink Sack @7036 had no stated durability for its recipe of Objet D'art. However, after quick testing on the CivTest server, there was no indication that the ink sacks were ignored in the creation process.

If anything goes wrong with this, then I'm not sure why Yaml hates me =_=.
