### PR TITLE
Fixed an Error in Dye Clay Factory

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -2163,7 +2163,6 @@ production_factories:
         durability: 10
       Hardened Clay:
         material: HARD_CLAY
-        durability: 7
   Stained_Glass_Processing:
     name: Stained Glass Processing
     fuel:


### PR DESCRIPTION
Someone put a damage value on Hardened Clay, making it wanting a block named "Hardened Clay" that is gray.
