### PR TITLE
Add eyes of ender to the explosives factory

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1980,6 +1980,7 @@ production_factories:
     recipes:
       - Produce_TNT
       - Produce_Fire_Charges
+      - Produce_Eyes_of_Ender
       - Bastion_Silicon_Tetranitratobihydrotrioxycarbon
     repair_multiple: 10
     repair_inputs:
@@ -3759,6 +3760,20 @@ production_recipes:
       Fire Charge:
         material: FIREBALL
         amount: 128
+  Produce_Eyes_of_Ender:
+    name: Produce Eyes of Ender
+    production_time: 8
+    inputs:
+      Ender pearls:
+        material: ENDER_PEARL
+        amount: 32
+      Blaze Powder:
+        material: BLAZE_POWDER
+        amount: 16
+    outputs:
+      Eyes of Ender:
+        material: EYE_OF_ENDER
+        amount: 32
   Dye_White_Wool_Green:
     name: Dye White Wool Green
     inputs:


### PR DESCRIPTION
Heard fk_54 mention a few times that eyes of ender aren't craftable, can't find a deliberate block on this. Haven't tested but have added a factory here for review, doesn't boost efficiency much but should work around any issue there.

Added to explosives factory:

<pre><code>32 Eyes of Ender for 32 Ender Pearl, 16 Blaze Powder</code></pre>
