### PR TITLE
Fix Handling of Enchanted Books as Inputs to Create Factories

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1909,19 +1909,19 @@ production_factories:
         material: GLASS_BOTTLE
         amount: 512
       Pig eggs:
-        material: SPAWN_EGG
+        material: MONSTER_EGG
         durability: 90
         amount: 16
       Villager eggs:
-        material: SPAWN_EGG
+        material: MONSTER_EGG
         durability: 120
         amount: 16
       Squid eggs:
-        material: SPAWN_EGG
+        material: MONSTER_EGG
         durability: 94
         amount: 16
       Horse eggs:
-        material: SPAWN_EGG
+        material: MONSTER_EGG
         durability: 100
         amount: 16
       Silk touch book:
@@ -1946,19 +1946,19 @@ production_factories:
         material: GLASS_BOTTLE
         amount: 32
       Pig eggs:
-        material: SPAWN_EGG
+        material: MONSTER_EGG
         durability: 90
         amount: 1
       Villager eggs:
-        material: SPAWN_EGG
+        material: MONSTER_EGG
         durability: 120
         amount: 1
       Squid eggs:
-        material: SPAWN_EGG
+        material: MONSTER_EGG
         durability: 94
         amount: 1
       Horse eggs:
-        material: SPAWN_EGG
+        material: MONSTER_EGG
         durability: 100
         amount: 1
   Explosives_Factory:
@@ -4223,6 +4223,7 @@ production_recipes:
         amount: 4
         durability: 6
     outputs:
+
       Cyan Wool:
         material: WOOL
         amount: 64
@@ -6838,16 +6839,16 @@ production_recipes:
     production_time: 4
     inputs:
       Pig eggs:
-        material: SPAWN_EGG
+        material: MONSTER_EGG
         durability: 90
         amount: 16
       Villager eggs:
-        material: SPAWN_EGG
+        material: MONSTER_EGG
         durability: 120
         amount: 16
     outputs:
       Pigman eggs:
-        material: SPAWN_EGG
+        material: MONSTER_EGG
         durability: 57
         amount: 16
   Infect_Zombies:
@@ -6855,7 +6856,7 @@ production_recipes:
     production_time: 4
     inputs:
       Villager eggs:
-        material: SPAWN_EGG
+        material: MONSTER_EGG
         durability: 120
         amount: 16
       Rotten flesh:
@@ -6863,7 +6864,7 @@ production_recipes:
         amount: 512
     outputs:
       Zombie eggs:
-        material: SPAWN_EGG
+        material: MONSTER_EGG
         durability: 54
         amount: 8
   Mutate_Skeletons:
@@ -6871,7 +6872,7 @@ production_recipes:
     production_time: 4
     inputs:
       Zombie eggs:
-        material: SPAWN_EGG
+        material: MONSTER_EGG
         durability: 54
         amount: 16
       Bones:
@@ -6882,7 +6883,7 @@ production_recipes:
         amount: 64
     outputs:
       Skeleton eggs:
-        material: SPAWN_EGG
+        material: MONSTER_EGG
         durability: 51
         amount: 8
   Mutate_Creepers:
@@ -6890,7 +6891,7 @@ production_recipes:
     production_time: 4
     inputs:
       Skeleton eggs:
-        material: SPAWN_EGG
+        material: MONSTER_EGG
         durability: 51
         amount: 16
       Blaze powder:
@@ -6905,7 +6906,7 @@ production_recipes:
         amount: 32
     outputs:
       Creeper eggs:
-        material: SPAWN_EGG
+        material: MONSTER_EGG
         durability: 50
         amount: 8
   Mutate_Witches:
@@ -6913,7 +6914,7 @@ production_recipes:
     production_time: 32
     inputs:
       Villager eggs:
-        material: SPAWN_EGG
+        material: MONSTER_EGG
         durability: 120
         amount: 16
       Ghast tears:
@@ -6921,7 +6922,7 @@ production_recipes:
         amount: 16
     outputs:
       Witch eggs:
-        material: SPAWN_EGG
+        material: MONSTER_EGG
         durability: 66
         amount: 4
   Mutate_Spiders:
@@ -6929,11 +6930,11 @@ production_recipes:
     production_time: 16
     inputs:
       Squid eggs: # For the legs
-        material: SPAWN_EGG
+        material: MONSTER_EGG
         durability: 94
         amount: 16
       Cow eggs: # For food
-        material: SPAWN_EGG
+        material: MONSTER_EGG
         durability: 92
         amount: 16
       Spider eyes:
@@ -6941,7 +6942,7 @@ production_recipes:
         amount: 256
     outputs:
       Spider eggs:
-        material: SPAWN_EGG
+        material: MONSTER_EGG
         durability: 52
         amount: 4
   Mutate_Cave_Spiders:
@@ -6949,7 +6950,7 @@ production_recipes:
     production_time: 16
     inputs:
       Spider eggs:
-        material: SPAWN_EGG
+        material: MONSTER_EGG
         durability: 52
         amount: 16
       Poison potatoes:
@@ -6960,7 +6961,7 @@ production_recipes:
         amount: 256
     outputs:
       Cave spider eggs:
-        material: SPAWN_EGG
+        material: MONSTER_EGG
         durability: 59
         amount: 8
   Mutate_Ghasts:
@@ -6987,12 +6988,12 @@ production_recipes:
         durability: 1
         amount: 256
       Villager eggs: # Operator
-        material: SPAWN_EGG
+        material: MONSTER_EGG
         durability: 120
         amount: 4
     outputs:
       Ghast eggs:
-        material: SPAWN_EGG
+        material: MONSTER_EGG
         durability: 56
         amount: 4
   Compact_Ice:

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,4 +1,4 @@
 name: FactoryMod
 main: com.github.igotyou.FactoryMod.FactoryModPlugin
 author: igotyou
-version: 1.0
+version: 1.1

--- a/src/com/github/igotyou/FactoryMod/FactoryModPlugin.java
+++ b/src/com/github/igotyou/FactoryMod/FactoryModPlugin.java
@@ -320,7 +320,11 @@ public class FactoryModPlugin extends JavaPlugin
 				String materialName=configItem.getString("material");
 				Material material = Material.getMaterial(materialName);
 				//only proceeds if an acceptable material name was provided
-				if(material!=null)
+				if (material == null)
+				{
+					getLogger().severe(configItems.getCurrentPath() + " requires invalid material " + materialName);
+				}
+				else
 				{
 					int amount=configItem.getInt("amount",1);
 					short durability=(short)configItem.getInt("durability",0);

--- a/src/com/github/igotyou/FactoryMod/FactoryModPlugin.java
+++ b/src/com/github/igotyou/FactoryMod/FactoryModPlugin.java
@@ -340,7 +340,7 @@ public class FactoryModPlugin extends JavaPlugin
 	private NamedItemStack createItemStack(Material material,int stackSize,short durability,String name,String loreString,String commonName,int repairCost,List<ProbabilisticEnchantment> compulsoryEnchants,List<ProbabilisticEnchantment> storedEnchants, List<PotionEffect> potionEffects)
 	{
 		NamedItemStack namedItemStack= new NamedItemStack(material, stackSize, durability,commonName);
-		if(name!=null||loreString!=null||compulsoryEnchants.size()>0||repairCost > 0)
+		if(name!=null||loreString!=null||compulsoryEnchants.size()>0||storedEnchants.size()>0||repairCost > 0)
 		{
 			ItemMeta meta=namedItemStack.getItemMeta();
 			if (name!=null)

--- a/src/com/github/igotyou/FactoryMod/FactoryModPlugin.java
+++ b/src/com/github/igotyou/FactoryMod/FactoryModPlugin.java
@@ -344,7 +344,7 @@ public class FactoryModPlugin extends JavaPlugin
 	private NamedItemStack createItemStack(Material material,int stackSize,short durability,String name,String loreString,String commonName,int repairCost,List<ProbabilisticEnchantment> compulsoryEnchants,List<ProbabilisticEnchantment> storedEnchants, List<PotionEffect> potionEffects)
 	{
 		NamedItemStack namedItemStack= new NamedItemStack(material, stackSize, durability,commonName);
-		if(name!=null||loreString!=null||compulsoryEnchants.size()>0||storedEnchants.size()>0||repairCost > 0)
+		if(name!=null||loreString!=null||compulsoryEnchants.size()>0||storedEnchants.size()>0||potionEffects.size()>0||repairCost > 0)
 		{
 			ItemMeta meta=namedItemStack.getItemMeta();
 			if (name!=null)


### PR DESCRIPTION
After adding more tracing I discovered that FactoryModPlugin.createItemStack()
was not using the storedEnchants argument due to a faulty if-condition.
Trivial fix.

Tested with a custom "String Recycler" factory that requires wool and a Silk Touch book to create because the Mad Scientist Factory takes too long to set up.
