### PR TITLE
add donkey double chest recipe to animal husbandry factory

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1637,6 +1637,7 @@ production_factories:
        - Produce_Gold_Horse_Armor
        - Produce_Iron_Horse_Armor
        - Produce_Leads
+       - Produce_Donkey_Chest
    repair_multiple: 6
    repair_inputs:
      Iron Block:
@@ -5919,6 +5920,20 @@ production_recipes:
       Lead:
         material: LEASH
         amount: 8
+  Produce_Donkey_Chest:
+    name: Produce Donkey Chest
+    inputs:
+      Ender Chest:
+        material: ENDER_CHEST
+        amount: 8
+      Saddle:
+        material: SADDLE
+        amount: 4
+    outputs:
+      Donkey Double Chest:
+        material: CHEST
+        amount: 4
+        lore: Donkey double chest
   Craft_Fences:
     name: Craft Fences
     production_time: 16


### PR DESCRIPTION
Input 8 enderchest, 4 saddles, output 4 chests with "Donkey double chest" lore for the donkey plugin.

ALTERNATIVELY: create a command block on civtest with this input

```
summon Item ~ ~ ~ {Item:{id:54, Count:1,tag:{display:{Lore:["Donkey double chest"]}}}}
```

which would be much easier if you just want to test the donkey plugin.
