### PR TITLE
Sequencing Poppy & Dandelion added to Bio Factory

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1910,6 +1910,8 @@ production_factories:
       - Sequencing_Large_Fern
       - Sequencing_Rose_Bush
       - Sequencing_Peony
+      - Sequencing_Poppy
+      - Sequencing_Dandelion
     repair_multiple: 10
     repair_inputs:
       Oak Saplings:
@@ -7419,6 +7421,30 @@ production_recipes:
         material: DOUBLE_PLANT
         amount: 4
         durability: 5
+  Sequencing_Poppy:
+    name: Sequencing Poppy
+    production_time: 32
+    inputs:
+      Bone Meal:
+        material: INK_SACK
+        amount: 96
+        durability: 15
+    outputs:
+      Poppy:
+        material: RED_ROSE
+        amount: 32
+  Sequencing_Dandelion:
+    name: Sequencing Dandelion
+    production_time: 32
+    inputs:
+      Bone Meal:
+        material: INK_SACK
+        amount: 96
+        durability: 15
+    outputs:
+      Dandelion:
+        material: YELLOW_FLOWER
+        amount: 32
   Aspect_Factory:
     name: Arcane Elementizer
     fuel:


### PR DESCRIPTION
Two recipes are added for the Bio Factory, for the creation of making
Poppy and Dandelion flowers.

Time: 32 Seconds
Fuel Cost: 16 Charcoal
Input: 96 Bone meal

Output: 32 Poppy/Dandelion (Dependent on which you choose)
