### PR TITLE
Potato Wood Cauldron Nerf

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -2657,7 +2657,7 @@ production_recipes:
         amount: 5
       Baked Potato:
         material: BAKED_POTATO
-        amount: 1280
+        amount: 1920
     outputs:
       Exp Bottle:
         material: EXP_BOTTLE


### PR DESCRIPTION
The potato recipe in the wood cauldron can currently produce 1.5x as much xp/hour as the carrot recipe.  Rather than buffing the carrot recipe to bring it in line with the potato 1, it's better to nerf the potato recipe as the wood cauldron is already OP due to bots.
